### PR TITLE
Replace spaces chromeExtensionID with c3 Examples extension

### DIFF
--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -23,7 +23,7 @@ export const iceServers = [{
 export const serverUrl = 'https://demo.cct.ericsson.net'
 
 export const screenSharingFrameRate = 5
-export const chromeExtensionId = 'cnmkhalfebkmaacaikplgjoeifnfplfb'
+export const chromeExtensionId = 'epajpkbdigdpepgncdpmilaoamkjgoah'
 export const firefoxExtensionUrl = 'missing.xpi'
 export const firefoxExtensionHash = 'tbd'
 


### PR DESCRIPTION
Before being able to use this extension id you should add the following plugin. https://chrome.google.com/webstore/detail/c3-example-extension/epajpkbdigdpepgncdpmilaoamkjgoah
